### PR TITLE
Fix yolox config and README.

### DIFF
--- a/132_YOLOX/demo/tflite/README.md
+++ b/132_YOLOX/demo/tflite/README.md
@@ -42,12 +42,12 @@ Run demo.
 cd ~/tflite-cv-exampl/eyolox/python
 
 # Camera input demo.
-python yolox_tflite_capture_opencv.py \
+python yolox_tflite_demo.py \
   --model PATH_TO_TFLITE_MODEL_FILE \
   --label ./data/coco_labels.txt
 
 # Video file input demo.
-python yolox_tflite_capture_opencv.py 
+python yolox_tflite_demo.py 
   --model PATH_TO_TFLITE_MODEL_FILE \
   --label ../data/coco_labels.txt \
   --videopath PATH_TO_VIDEO_FILE

--- a/132_YOLOX/weight_replacement_config_yolox_tiny.json
+++ b/132_YOLOX/weight_replacement_config_yolox_tiny.json
@@ -2,7 +2,7 @@
     "format_version": 1,
     "layers": [
         {
-            "layer_id": "459",
+            "layer_id": "509",
             "replace_mode": "direct",
             "values": [
                 0,


### PR DESCRIPTION
- Modify the layer_id in `weight_replacement_config_yolox_tiny.json`.
- Correct the incorrect file name in the README.