### PR TITLE
Fix missing download_*.sh files

### DIFF
--- a/017_Artistic-Style-Transfer/official/download_new.sh
+++ b/017_Artistic-Style-Transfer/official/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1TUhEqgNij1KzL34GhMGipm4lH_eJQBtW" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1TUhEqgNij1KzL34GhMGipm4lH_eJQBtW" -o resources.tar.gz
+fileid="1TUhEqgNij1KzL34GhMGipm4lH_eJQBtW"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/018_EfficientDet/09_pytorch_efficientdet_d0/download_hard-swish.sh
+++ b/018_EfficientDet/09_pytorch_efficientdet_d0/download_hard-swish.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1FW7qGPXxVAMtk9D2JKRLsPeWDejDiyRb" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1FW7qGPXxVAMtk9D2JKRLsPeWDejDiyRb" -o resources.tar.gz
+fileid="1FW7qGPXxVAMtk9D2JKRLsPeWDejDiyRb"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/023_yolov3-nano/download_saved_model.sh
+++ b/023_yolov3-nano/download_saved_model.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=11pbvvFJLAS7qLv68odP80Ea6CYkjlQGi" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=11pbvvFJLAS7qLv68odP80Ea6CYkjlQGi" -o saved_model.tar.gz
+fileid="11pbvvFJLAS7qLv68odP80Ea6CYkjlQGi"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o saved_model.tar.gz
 tar -zxvf saved_model.tar.gz
 rm saved_model.tar.gz
 echo Download finished.

--- a/030_BlazeFace/01_float32/download_new.sh
+++ b/030_BlazeFace/01_float32/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1DOEH2xS_bGVXEsriNJkKE3my62ZH3FUl" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1DOEH2xS_bGVXEsriNJkKE3my62ZH3FUl" -o resources.tar.gz
+fileid="1DOEH2xS_bGVXEsriNJkKE3my62ZH3FUl"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/02_weight_quantization/download_new.sh
+++ b/030_BlazeFace/02_weight_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1UV4UG5zLDKPiBHxeZ_r78AXfC3DEoZAK" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1UV4UG5zLDKPiBHxeZ_r78AXfC3DEoZAK" -o resources.tar.gz
+fileid="1UV4UG5zLDKPiBHxeZ_r78AXfC3DEoZAK"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/03_integer_quantization/download_new.sh
+++ b/030_BlazeFace/03_integer_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1ANCKfeDy66OYySbHTf9AwJTOlXw57T75" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1ANCKfeDy66OYySbHTf9AwJTOlXw57T75" -o resources.tar.gz
+fileid="1ANCKfeDy66OYySbHTf9AwJTOlXw57T75"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/04_full_integer_quantization/download_new.sh
+++ b/030_BlazeFace/04_full_integer_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1zdjTC0g1APpSXvm0sDe8D-zPJj4DMo4w" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1zdjTC0g1APpSXvm0sDe8D-zPJj4DMo4w" -o resources.tar.gz
+fileid="1zdjTC0g1APpSXvm0sDe8D-zPJj4DMo4w"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/05_float16_quantization/download_new.sh
+++ b/030_BlazeFace/05_float16_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1kRgsTPxP253PjSzUk86ZKEWvZhpoH2GF" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1kRgsTPxP253PjSzUk86ZKEWvZhpoH2GF" -o resources.tar.gz
+fileid="1kRgsTPxP253PjSzUk86ZKEWvZhpoH2GF"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/06_edgetpu/download_new.sh
+++ b/030_BlazeFace/06_edgetpu/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1dqDUagb5D6yvQy7xgoipF0QEW1gzs8VO" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1dqDUagb5D6yvQy7xgoipF0QEW1gzs8VO" -o resources.tar.gz
+fileid="1dqDUagb5D6yvQy7xgoipF0QEW1gzs8VO"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/07_openvino/download_new.sh
+++ b/030_BlazeFace/07_openvino/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1NGZeHXLQc2a5YMqIpAWa6jmjZiXZAuAv" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1NGZeHXLQc2a5YMqIpAWa6jmjZiXZAuAv" -o resources.tar.gz
+fileid="1NGZeHXLQc2a5YMqIpAWa6jmjZiXZAuAv"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/08_coreml/download_new.sh
+++ b/030_BlazeFace/08_coreml/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1CDZ0xsKl2---zi4Jp6GbJqytLVPTr5ud" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1CDZ0xsKl2---zi4Jp6GbJqytLVPTr5ud" -o resources.tar.gz
+fileid="1CDZ0xsKl2---zi4Jp6GbJqytLVPTr5ud"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/09_tfjs/download_new.sh
+++ b/030_BlazeFace/09_tfjs/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=15HniFQX6MpyxK1foDeebxhNOkEfQOCLw" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=15HniFQX6MpyxK1foDeebxhNOkEfQOCLw" -o resources.tar.gz
+fileid="15HniFQX6MpyxK1foDeebxhNOkEfQOCLw"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/030_BlazeFace/10_tftrt/download_new.sh
+++ b/030_BlazeFace/10_tftrt/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1YZHThtFlUQtTi6RpNiQu6KaOsFAijZQx" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1YZHThtFlUQtTi6RpNiQu6KaOsFAijZQx" -o resources.tar.gz
+fileid="1YZHThtFlUQtTi6RpNiQu6KaOsFAijZQx"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/032_FaceMesh/04_full_integer_quantization/download_uint8.sh
+++ b/032_FaceMesh/04_full_integer_quantization/download_uint8.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1z77ayo8NrjP76S9TaOEgN4zMIzcwgvZr" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1z77ayo8NrjP76S9TaOEgN4zMIzcwgvZr" -o resources.tar.gz
+fileid="1z77ayo8NrjP76S9TaOEgN4zMIzcwgvZr"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/01_float32/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/01_float32/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1_m71liRij6gheKq1O24RrI4Ct6ZKIst1" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1_m71liRij6gheKq1O24RrI4Ct6ZKIst1" -o resources.tar.gz
+fileid="1_m71liRij6gheKq1O24RrI4Ct6ZKIst1"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/02_weight_quantization/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/02_weight_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=13HvTVGP8tifWkKjjH2feJJqH-uMrqc_R" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=13HvTVGP8tifWkKjjH2feJJqH-uMrqc_R" -o resources.tar.gz
+fileid="13HvTVGP8tifWkKjjH2feJJqH-uMrqc_R"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/03_integer_quantization/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/03_integer_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1E_eUtAqzZ1xsVtOzXSlnDDzlwLTvn2Zk" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1E_eUtAqzZ1xsVtOzXSlnDDzlwLTvn2Zk" -o resources.tar.gz
+fileid="1E_eUtAqzZ1xsVtOzXSlnDDzlwLTvn2Zk"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/04_float16_quantization/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/04_float16_quantization/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1BJk1FoPGMdVe1ZH-ObeCDNOQmqoE1k4c" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1BJk1FoPGMdVe1ZH-ObeCDNOQmqoE1k4c" -o resources.tar.gz
+fileid="1BJk1FoPGMdVe1ZH-ObeCDNOQmqoE1k4c"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/05_coreml/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/05_coreml/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1Lzdji_KUp3eG-ew92JMbY56gahQ6nBdO" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1Lzdji_KUp3eG-ew92JMbY56gahQ6nBdO" -o resources.tar.gz
+fileid="1Lzdji_KUp3eG-ew92JMbY56gahQ6nBdO"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/06_tfjs/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/06_tfjs/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1H85mWZpwsKrqy1KPgRUkYhjqi6aqZXmM" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1H85mWZpwsKrqy1KPgRUkYhjqi6aqZXmM" -o resources.tar.gz
+fileid="1H85mWZpwsKrqy1KPgRUkYhjqi6aqZXmM"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/07_openvino/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/07_openvino/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1Ff3OvLvGx7u5jzC8Ru8Ycv5W6doDvltl" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1Ff3OvLvGx7u5jzC8Ru8Ycv5W6doDvltl" -o resources.tar.gz
+fileid="1Ff3OvLvGx7u5jzC8Ru8Ycv5W6doDvltl"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/08_tftrt/download_new.sh
+++ b/033_Hand_Detection_and_Tracking/08_tftrt/download_new.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1DNX5s8NfH2A4GlpF8wA6AXo8RtXC75Bh" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1DNX5s8NfH2A4GlpF8wA6AXo8RtXC75Bh" -o resources.tar.gz
+fileid="1DNX5s8NfH2A4GlpF8wA6AXo8RtXC75Bh"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/10_new_128x128/download_resources.sh
+++ b/033_Hand_Detection_and_Tracking/10_new_128x128/download_resources.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1VTCUEuvPpkGY4MOepzoUjlpIPLi_SKwX" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1VTCUEuvPpkGY4MOepzoUjlpIPLi_SKwX" -o resources.tar.gz
+fileid="1VTCUEuvPpkGY4MOepzoUjlpIPLi_SKwX"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/10_new_128x128/download_saved_model_128x128.sh
+++ b/033_Hand_Detection_and_Tracking/10_new_128x128/download_saved_model_128x128.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1mW5S0abcelUsDwUARTkEapf33AiSEIz4" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1mW5S0abcelUsDwUARTkEapf33AiSEIz4" -o resources.tar.gz
+fileid="1mW5S0abcelUsDwUARTkEapf33AiSEIz4"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/033_Hand_Detection_and_Tracking/10_new_128x128/download_saved_model_for_edgetpu_128x128.sh
+++ b/033_Hand_Detection_and_Tracking/10_new_128x128/download_saved_model_for_edgetpu_128x128.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1ueG-xNes_C7kqqyawrmuK1RpY-oh498J" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1ueG-xNes_C7kqqyawrmuK1RpY-oh498J" -o resources.tar.gz
+fileid="1ueG-xNes_C7kqqyawrmuK1RpY-oh498J"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_kpts_320x320.sh
+++ b/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_kpts_320x320.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1cFgcmYnp_LLzEbthX6CDQ_QPSJT0Up9i" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1cFgcmYnp_LLzEbthX6CDQ_QPSJT0Up9i" -o resources.tar.gz
+fileid="1cFgcmYnp_LLzEbthX6CDQ_QPSJT0Up9i"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_kpts_320x320_openvino.sh
+++ b/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_kpts_320x320_openvino.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=11vgmgtK0d-A-kMkOGSLA51_3b3FqYREF" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=11vgmgtK0d-A-kMkOGSLA51_3b3FqYREF" -o resources.tar.gz
+fileid="11vgmgtK0d-A-kMkOGSLA51_3b3FqYREF"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_kpts_480x640.sh
+++ b/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_kpts_480x640.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1niJFlVqg189eYaAQ02NwZf0kRFWVsY31" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1niJFlVqg189eYaAQ02NwZf0kRFWVsY31" -o resources.tar.gz
+fileid="1niJFlVqg189eYaAQ02NwZf0kRFWVsY31"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_od_320x320.sh
+++ b/042_centernet/20_tensorflow_models/download_centernet_mobilenetv2_fpn_od_320x320.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1OBfod9IAj7F7GpGfDx-QRjERuM3Ydtur" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1OBfod9IAj7F7GpGfDx-QRjERuM3Ydtur" -o resources.tar.gz
+fileid="1OBfod9IAj7F7GpGfDx-QRjERuM3Ydtur"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/053_BlazePose/10_lite_full_heavy_version_May6_2021/download_full.sh
+++ b/053_BlazePose/10_lite_full_heavy_version_May6_2021/download_full.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1z09FVeGGS_eKE03wnloP0IPmJcMLQ64e" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1z09FVeGGS_eKE03wnloP0IPmJcMLQ64e" -o resources.tar.gz
+fileid="1z09FVeGGS_eKE03wnloP0IPmJcMLQ64e"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/053_BlazePose/10_lite_full_heavy_version_May6_2021/download_heavy.sh
+++ b/053_BlazePose/10_lite_full_heavy_version_May6_2021/download_heavy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1MPpJN3uDtr2xn55xVGj0eB-nqyKrQGeU" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1MPpJN3uDtr2xn55xVGj0eB-nqyKrQGeU" -o resources.tar.gz
+fileid="1MPpJN3uDtr2xn55xVGj0eB-nqyKrQGeU"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/053_BlazePose/10_lite_full_heavy_version_May6_2021/download_lite.sh
+++ b/053_BlazePose/10_lite_full_heavy_version_May6_2021/download_lite.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1pefn36-rfwwYLvaIuNZlkzLbSOiCCcOz" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1pefn36-rfwwYLvaIuNZlkzLbSOiCCcOz" -o resources.tar.gz
+fileid="1pefn36-rfwwYLvaIuNZlkzLbSOiCCcOz"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/061_U-2-Net/30_human_segmentation/download_120x160.sh
+++ b/061_U-2-Net/30_human_segmentation/download_120x160.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1TEZiDhnyeM9z3Kwi4_wN79NJuemZOPek" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1TEZiDhnyeM9z3Kwi4_wN79NJuemZOPek" -o resources.tar.gz
+fileid="1TEZiDhnyeM9z3Kwi4_wN79NJuemZOPek"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/061_U-2-Net/30_human_segmentation/download_160x96.sh
+++ b/061_U-2-Net/30_human_segmentation/download_160x96.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=13QZbMC_tHWrruf3JJhiFqZ1c-Pfl9wHe" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=13QZbMC_tHWrruf3JJhiFqZ1c-Pfl9wHe" -o resources.tar.gz
+fileid="13QZbMC_tHWrruf3JJhiFqZ1c-Pfl9wHe"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/061_U-2-Net/30_human_segmentation/download_240x320.sh
+++ b/061_U-2-Net/30_human_segmentation/download_240x320.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=11fMkPOokMH5dythzCaXkvzP-KHTSwi3M" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=11fMkPOokMH5dythzCaXkvzP-KHTSwi3M" -o resources.tar.gz
+fileid="11fMkPOokMH5dythzCaXkvzP-KHTSwi3M"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/061_U-2-Net/30_human_segmentation/download_256x144.sh
+++ b/061_U-2-Net/30_human_segmentation/download_256x144.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1qu0iZ0K11Kwu8bdC9ls47A-y4ROWqkFe" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1qu0iZ0K11Kwu8bdC9ls47A-y4ROWqkFe" -o resources.tar.gz
+fileid="1qu0iZ0K11Kwu8bdC9ls47A-y4ROWqkFe"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/061_U-2-Net/30_human_segmentation/download_320x320.sh
+++ b/061_U-2-Net/30_human_segmentation/download_320x320.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=152SdlygqIM6hi4JqfnwY5fbK617iQbya" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=152SdlygqIM6hi4JqfnwY5fbK617iQbya" -o resources.tar.gz
+fileid="152SdlygqIM6hi4JqfnwY5fbK617iQbya"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/061_U-2-Net/30_human_segmentation/download_480x640.sh
+++ b/061_U-2-Net/30_human_segmentation/download_480x640.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1AqcwwnBwxL7kzchr83WktUy7M3RqqAXa" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1AqcwwnBwxL7kzchr83WktUy7M3RqqAXa" -o resources.tar.gz
+fileid="1AqcwwnBwxL7kzchr83WktUy7M3RqqAXa"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/079_MIRNet/old/download_128x128.sh
+++ b/079_MIRNet/old/download_128x128.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1zWIdrWVlU0pst_dS2akMPpao1UhyMmeV" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1zWIdrWVlU0pst_dS2akMPpao1UhyMmeV" -o resources.tar.gz
+fileid="1zWIdrWVlU0pst_dS2akMPpao1UhyMmeV"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/079_MIRNet/old/download_256x256.sh
+++ b/079_MIRNet/old/download_256x256.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1v3v2k9ZZjLd6Fzx1_sioc-l4BwminsVC" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1v3v2k9ZZjLd6Fzx1_sioc-l4BwminsVC" -o resources.tar.gz
+fileid="1v3v2k9ZZjLd6Fzx1_sioc-l4BwminsVC"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/079_MIRNet/old/download_320x320.sh
+++ b/079_MIRNet/old/download_320x320.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1kDXJMq7f8IgBSU7Eq0CNkgYcQnXadxMo" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1kDXJMq7f8IgBSU7Eq0CNkgYcQnXadxMo" -o resources.tar.gz
+fileid="1kDXJMq7f8IgBSU7Eq0CNkgYcQnXadxMo"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/079_MIRNet/old/download_416x416.sh
+++ b/079_MIRNet/old/download_416x416.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1Wg5rAmKPTi90E3-LdRuogzWUDi-VzCZR" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1Wg5rAmKPTi90E3-LdRuogzWUDi-VzCZR" -o resources.tar.gz
+fileid="1Wg5rAmKPTi90E3-LdRuogzWUDi-VzCZR"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/079_MIRNet/old/download_512x512.sh
+++ b/079_MIRNet/old/download_512x512.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=11hJQM3F1JoMIBDAbYIb91YrqeXPFg8nb" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=11hJQM3F1JoMIBDAbYIb91YrqeXPFg8nb" -o resources.tar.gz
+fileid="11hJQM3F1JoMIBDAbYIb91YrqeXPFg8nb"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 

--- a/079_MIRNet/old/download_64x64.sh
+++ b/079_MIRNet/old/download_64x64.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1YV2EzON3_Lr-ypkB9Cj-G1Yjg2cb2jMe" > /dev/null
-CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
-curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1YV2EzON3_Lr-ypkB9Cj-G1Yjg2cb2jMe" -o resources.tar.gz
+fileid="1YV2EzON3_Lr-ypkB9Cj-G1Yjg2cb2jMe"
+html=`curl -c ./cookie -s -L "https://drive.google.com/uc?export=download&id=${fileid}"`
+curl -Lb ./cookie "https://drive.google.com/uc?export=download&`echo ${html}|grep -Po '(confirm=[a-zA-Z0-9\-_]+)'`&id=${fileid}" -o resources.tar.gz
 tar -zxvf resources.tar.gz
 rm resources.tar.gz
 


### PR DESCRIPTION
This PR fixes the error in [#239](https://github.com/PINTO0309/PINTO_model_zoo/pull/239) where only the "download.sh" files were converted. This PR adds the remaining  download_*.sh scripts that were not converted previously.

Updated conversion script: https://gist.github.com/ibaiGorordo/69988fbf83a045e6c58701aa03eb423f